### PR TITLE
Have auth url be configurable from database

### DIFF
--- a/classes/provider/ifsta.php
+++ b/classes/provider/ifsta.php
@@ -39,6 +39,10 @@ class provideroauth2ifsta extends Osufpp\OAuth2\Client\Provider\Ifsta {
             'redirectUri'   => $CFG->wwwroot .'/auth/googleoauth2/' . $this->name . '_redirect.php',
             'scopes'        => $this->scopes
         ]);
+        
+        // Set domain defined in the parent class to the appropriate one for our environment:
+        $authurl = get_config('auth/googleoauth2', $this->name . 'authurl');
+        if ($authurl) $this->domain = $authurl;
     }
 
     /**


### PR DESCRIPTION
Set the `domain` property of the base class in [osufpp/oauth2-ifsta](https://github.com/osufpp/oauth2-ifsta) according to a database setting.

To configure a moodle test site, then, one would do

```
INSERT INTO mdl_config_plugins (plugin, name, value) VALUES ('auth/googleoauth2', 'ifstaauthurl', 'https://auth-test.ifsta.org');
```

Note that config values (in the `mdl_config_plugins` table, accessed by `get_config`) are cached, and one must run (on the moodle server):

```
cd /opt/moodle
sudo -u moodle /usr/bin/php admin/cli/purge_caches.php
```

to clear the cache